### PR TITLE
Integrate app intents with mock data

### DIFF
--- a/MockDataService.swift
+++ b/MockDataService.swift
@@ -1,0 +1,312 @@
+//
+//  MockDataService.swift
+//  ANIS
+//
+//  Created by Assistant
+//
+
+import Foundation
+
+// MARK: - Data Models
+
+struct Activity: Identifiable, Codable {
+    let id: String
+    let title: String
+    let description: String?
+    let sportType: String
+    let dateTime: Date
+    let location: String
+    let maxParticipants: Int
+    let currentParticipants: Int
+    let creatorId: String
+    let participantIds: [String]
+    
+    var availableSlots: Int {
+        return maxParticipants - currentParticipants
+    }
+    
+    var isAvailable: Bool {
+        return availableSlots > 0
+    }
+}
+
+struct User: Identifiable, Codable {
+    let id: String
+    let name: String
+    let email: String
+    let interests: [String]
+    let profileImageURL: String?
+    let createdActivities: [String] // Activity IDs
+    let joinedActivities: [String] // Activity IDs
+    
+    var totalActivities: Int {
+        return createdActivities.count + joinedActivities.count
+    }
+}
+
+// MARK: - Mock Data Service
+
+class MockDataService: ObservableObject {
+    static let shared = MockDataService()
+    
+    @Published var activities: [Activity] = []
+    @Published var users: [User] = []
+    @Published var currentUser: User?
+    
+    private init() {
+        loadMockData()
+    }
+    
+    // MARK: - Mock Data Loading
+    
+    private func loadMockData() {
+        // Mock Users
+        users = [
+            User(
+                id: "user1",
+                name: "John Doe",
+                email: "john@example.com",
+                interests: ["Padel", "Football", "Tennis"],
+                profileImageURL: nil,
+                createdActivities: ["1", "3"],
+                joinedActivities: ["2"]
+            ),
+            User(
+                id: "user2",
+                name: "Sarah Smith",
+                email: "sarah@example.com",
+                interests: ["Basketball", "Padel", "Swimming"],
+                profileImageURL: nil,
+                createdActivities: ["2"],
+                joinedActivities: ["1"]
+            ),
+            User(
+                id: "user3",
+                name: "Ahmed Al-Rashid",
+                email: "ahmed@example.com",
+                interests: ["Football", "Tennis", "Running"],
+                profileImageURL: nil,
+                createdActivities: ["4"],
+                joinedActivities: ["1", "3"]
+            )
+        ]
+        
+        // Set current user
+        currentUser = users.first
+        
+        // Mock Activities
+        activities = [
+            Activity(
+                id: "1",
+                title: "Morning Padel Session",
+                description: "Join us for an exciting padel match at the sports complex. All skill levels welcome!",
+                sportType: "Padel",
+                dateTime: Date().addingTimeInterval(3600), // 1 hour from now
+                location: "Sports Complex - Court 1",
+                maxParticipants: 4,
+                currentParticipants: 2,
+                creatorId: "user1",
+                participantIds: ["user1", "user2"]
+            ),
+            Activity(
+                id: "2",
+                title: "Football Training Session",
+                description: "Weekly football training session. Focus on passing and shooting drills.",
+                sportType: "Football",
+                dateTime: Date().addingTimeInterval(7200), // 2 hours from now
+                location: "Central Park - Field A",
+                maxParticipants: 22,
+                currentParticipants: 18,
+                creatorId: "user2",
+                participantIds: ["user2", "user1"] + (3...18).map { "participant\($0)" }
+            ),
+            Activity(
+                id: "3",
+                title: "Evening Tennis Match",
+                description: "Friendly tennis doubles match. Intermediate level players preferred.",
+                sportType: "Tennis",
+                dateTime: Date().addingTimeInterval(14400), // 4 hours from now
+                location: "Tennis Club - Court 3",
+                maxParticipants: 4,
+                currentParticipants: 3,
+                creatorId: "user1",
+                participantIds: ["user1", "user3", "participant19"]
+            ),
+            Activity(
+                id: "4",
+                title: "Basketball Pickup Game",
+                description: "Casual basketball game. Come ready to play!",
+                sportType: "Basketball",
+                dateTime: Date().addingTimeInterval(21600), // 6 hours from now
+                location: "Community Center - Indoor Court",
+                maxParticipants: 10,
+                currentParticipants: 7,
+                creatorId: "user3",
+                participantIds: ["user3"] + (20...25).map { "participant\($0)" }
+            ),
+            Activity(
+                id: "5",
+                title: "Swimming Workout",
+                description: "Structured swimming workout with coach guidance.",
+                sportType: "Swimming",
+                dateTime: Date().addingTimeInterval(28800), // 8 hours from now
+                location: "Aquatic Center - Pool 2",
+                maxParticipants: 15,
+                currentParticipants: 8,
+                creatorId: "user2",
+                participantIds: ["user2"] + (26...32).map { "participant\($0)" }
+            )
+        ]
+    }
+    
+    // MARK: - Activity Methods
+    
+    func findActivities(radius: Double = 10.0, sportType: String? = nil) -> [Activity] {
+        var filteredActivities = activities.filter { $0.dateTime > Date() }
+        
+        if let sportType = sportType {
+            filteredActivities = filteredActivities.filter { $0.sportType.lowercased() == sportType.lowercased() }
+        }
+        
+        return filteredActivities.sorted { $0.dateTime < $1.dateTime }
+    }
+    
+    func getActivity(by id: String) -> Activity? {
+        return activities.first { $0.id == id }
+    }
+    
+    func createActivity(
+        title: String,
+        description: String?,
+        sportType: String,
+        dateTime: Date,
+        location: String = "TBD",
+        maxParticipants: Int
+    ) -> Activity {
+        let newActivity = Activity(
+            id: UUID().uuidString,
+            title: title,
+            description: description,
+            sportType: sportType,
+            dateTime: dateTime,
+            location: location,
+            maxParticipants: maxParticipants,
+            currentParticipants: 1,
+            creatorId: currentUser?.id ?? "unknown",
+            participantIds: [currentUser?.id ?? "unknown"]
+        )
+        
+        activities.append(newActivity)
+        
+        // Update current user's created activities
+        if let currentUser = currentUser,
+           let userIndex = users.firstIndex(where: { $0.id == currentUser.id }) {
+            var updatedUser = users[userIndex]
+            updatedUser = User(
+                id: updatedUser.id,
+                name: updatedUser.name,
+                email: updatedUser.email,
+                interests: updatedUser.interests,
+                profileImageURL: updatedUser.profileImageURL,
+                createdActivities: updatedUser.createdActivities + [newActivity.id],
+                joinedActivities: updatedUser.joinedActivities
+            )
+            users[userIndex] = updatedUser
+            self.currentUser = updatedUser
+        }
+        
+        return newActivity
+    }
+    
+    func joinActivity(activityId: String, userId: String? = nil) -> (success: Bool, message: String, activity: Activity?) {
+        let userIdToUse = userId ?? currentUser?.id ?? "unknown"
+        
+        guard let activityIndex = activities.firstIndex(where: { $0.id == activityId }) else {
+            return (false, "Activity not found", nil)
+        }
+        
+        var activity = activities[activityIndex]
+        
+        if activity.participantIds.contains(userIdToUse) {
+            return (false, "You are already registered for this activity", activity)
+        }
+        
+        if !activity.isAvailable {
+            return (false, "Activity is full", activity)
+        }
+        
+        // Update activity
+        let updatedActivity = Activity(
+            id: activity.id,
+            title: activity.title,
+            description: activity.description,
+            sportType: activity.sportType,
+            dateTime: activity.dateTime,
+            location: activity.location,
+            maxParticipants: activity.maxParticipants,
+            currentParticipants: activity.currentParticipants + 1,
+            creatorId: activity.creatorId,
+            participantIds: activity.participantIds + [userIdToUse]
+        )
+        
+        activities[activityIndex] = updatedActivity
+        
+        // Update user's joined activities
+        if let userIndex = users.firstIndex(where: { $0.id == userIdToUse }) {
+            var updatedUser = users[userIndex]
+            updatedUser = User(
+                id: updatedUser.id,
+                name: updatedUser.name,
+                email: updatedUser.email,
+                interests: updatedUser.interests,
+                profileImageURL: updatedUser.profileImageURL,
+                createdActivities: updatedUser.createdActivities,
+                joinedActivities: updatedUser.joinedActivities + [activityId]
+            )
+            users[userIndex] = updatedUser
+            
+            if userIdToUse == currentUser?.id {
+                self.currentUser = updatedUser
+            }
+        }
+        
+        return (true, "Successfully joined activity!", updatedActivity)
+    }
+    
+    func getUpcomingActivities(for userId: String? = nil) -> [Activity] {
+        let userIdToUse = userId ?? currentUser?.id ?? "unknown"
+        
+        return activities.filter { activity in
+            activity.dateTime > Date() && 
+            (activity.participantIds.contains(userIdToUse) || activity.creatorId == userIdToUse)
+        }.sorted { $0.dateTime < $1.dateTime }
+    }
+    
+    func getUserActivities(for userId: String? = nil) -> (created: [Activity], joined: [Activity]) {
+        let userIdToUse = userId ?? currentUser?.id ?? "unknown"
+        
+        let createdActivities = activities.filter { $0.creatorId == userIdToUse }
+        let joinedActivities = activities.filter { 
+            $0.participantIds.contains(userIdToUse) && $0.creatorId != userIdToUse 
+        }
+        
+        return (createdActivities, joinedActivities)
+    }
+    
+    // MARK: - User Methods
+    
+    func getUser(by id: String) -> User? {
+        return users.first { $0.id == id }
+    }
+    
+    func getCurrentUser() -> User? {
+        return currentUser
+    }
+    
+    func updateCurrentUser(_ user: User) {
+        if let index = users.firstIndex(where: { $0.id == user.id }) {
+            users[index] = user
+            currentUser = user
+        }
+    }
+}

--- a/app-intent.swift
+++ b/app-intent.swift
@@ -1,0 +1,366 @@
+//
+//  app-intent.swift
+//  ANIS
+//
+//  Created by shoog on 22/02/1447 AH.
+//
+import Foundation
+import AppIntents
+import SwiftUI
+
+// MARK: - App Intents
+
+struct FindActivitiesIntent: AppIntent {
+    static var title: LocalizedStringResource = "Find Activities"
+    static var description = IntentDescription("Find sports activities near you")
+
+    @Parameter(title: "Search Radius", default: 10.0)
+    var searchRadius: Double
+    
+    @Parameter(title: "Sport Type")
+    var sportType: String?
+
+    func perform() async throws -> some IntentResult & ReturnsValue<[ActivityIntentResult]> {
+        let mockService = MockDataService.shared
+        let activities = mockService.findActivities(radius: searchRadius, sportType: sportType)
+        
+        let intentResults = activities.map { activity in
+            ActivityIntentResult(
+                id: activity.id,
+                title: activity.title,
+                sportType: activity.sportType,
+                dateTime: activity.dateTime,
+                location: activity.location,
+                availableSlots: activity.availableSlots
+            )
+        }
+        
+        return .result(value: intentResults)
+    }
+}
+
+struct JoinActivityIntent: AppIntent {
+    static var title: LocalizedStringResource = "Join Activity"
+    static var description = IntentDescription("Join a sports activity")
+
+    @Parameter(title: "Activity ID")
+    var activityId: String
+
+    func perform() async throws -> some IntentResult & ReturnsValue<JoinResult> {
+        let mockService = MockDataService.shared
+        let joinResult = mockService.joinActivity(activityId: activityId)
+        
+        let result = JoinResult(
+            success: joinResult.success,
+            message: joinResult.message,
+            activityTitle: joinResult.activity?.title ?? "Unknown Activity"
+        )
+        
+        return .result(value: result)
+    }
+}
+
+struct CreateActivityIntent: AppIntent {
+    static var title: LocalizedStringResource = "Create Activity"
+    static var description = IntentDescription("Create a new sports activity")
+
+    @Parameter(title: "Title")
+    var title: String
+
+    @Parameter(title: "Sport Type")
+    var sportType: String
+
+    @Parameter(title: "Date and Time")
+    var dateTime: Date
+
+    @Parameter(title: "Max Participants", default: 10)
+    var maxParticipants: Int
+
+    @Parameter(title: "Description")
+    var description: String?
+    
+    @Parameter(title: "Location")
+    var location: String?
+
+    func perform() async throws -> some IntentResult & ReturnsValue<CreateActivityResult> {
+        let mockService = MockDataService.shared
+        
+        let newActivity = mockService.createActivity(
+            title: title,
+            description: description,
+            sportType: sportType,
+            dateTime: dateTime,
+            location: location ?? "TBD",
+            maxParticipants: maxParticipants
+        )
+        
+        let result = CreateActivityResult(
+            success: true,
+            message: "Activity '\(newActivity.title)' created successfully!",
+            activityId: newActivity.id
+        )
+        
+        return .result(value: result)
+    }
+}
+
+struct GetUserProfileIntent: AppIntent {
+    static var title: LocalizedStringResource = "Get User Profile"
+    static var description = IntentDescription("Get information about the current user")
+
+    func perform() async throws -> some IntentResult & ReturnsValue<UserProfileResult> {
+        let mockService = MockDataService.shared
+        
+        guard let currentUser = mockService.getCurrentUser() else {
+            throw AppIntentError.userNotFound
+        }
+        
+        let upcomingActivities = mockService.getUpcomingActivities()
+        
+        let result = UserProfileResult(
+            name: currentUser.name,
+            interests: currentUser.interests,
+            upcomingActivities: upcomingActivities.count,
+            totalActivities: currentUser.totalActivities
+        )
+        
+        return .result(value: result)
+    }
+}
+
+struct GetUpcomingActivitiesIntent: AppIntent {
+    static var title: LocalizedStringResource = "Get Upcoming Activities"
+    static var description = IntentDescription("Get your upcoming sports activities")
+
+    func perform() async throws -> some IntentResult & ReturnsValue<[ActivityIntentResult]> {
+        let mockService = MockDataService.shared
+        let upcomingActivities = mockService.getUpcomingActivities()
+        
+        let intentResults = upcomingActivities.map { activity in
+            ActivityIntentResult(
+                id: activity.id,
+                title: activity.title,
+                sportType: activity.sportType,
+                dateTime: activity.dateTime,
+                location: activity.location,
+                availableSlots: activity.availableSlots
+            )
+        }
+        
+        return .result(value: intentResults)
+    }
+}
+
+// MARK: - AppEntities
+
+struct ActivityIntentResult: AppEntity {
+    static var typeDisplayRepresentation = TypeDisplayRepresentation(name: "Activity")
+    static var defaultQuery = ActivityIntentQuery()
+    
+    typealias ID = String
+    var id: ID
+
+    let title: String
+    let sportType: String
+    let dateTime: Date
+    let location: String
+    let availableSlots: Int
+
+    var displayRepresentation: DisplayRepresentation {
+        DisplayRepresentation(
+            title: LocalizedStringResource(stringLiteral: title),
+            subtitle: LocalizedStringResource(stringLiteral: "\(sportType) • \(dateTime.formatted(date: .abbreviated, time: .shortened)) • \(location)")
+        )
+    }
+}
+
+struct JoinResult: AppEntity {
+    static var typeDisplayRepresentation = TypeDisplayRepresentation(name: "Join Result")
+    static var defaultQuery = JoinResultQuery()
+    typealias ID = String
+    var id: ID { message }
+
+    let success: Bool
+    let message: String
+    let activityTitle: String
+
+    var displayRepresentation: DisplayRepresentation {
+        let emoji = success ? "✅" : "❌"
+        return DisplayRepresentation(
+            title: LocalizedStringResource(stringLiteral: "\(emoji) \(message)"),
+            subtitle: LocalizedStringResource(stringLiteral: activityTitle)
+        )
+    }
+}
+
+struct CreateActivityResult: AppEntity {
+    static var typeDisplayRepresentation = TypeDisplayRepresentation(name: "Create Activity Result")
+    static var defaultQuery = CreateActivityResultQuery()
+    typealias ID = String
+    var id: ID { activityId }
+
+    let success: Bool
+    let message: String
+    let activityId: String
+
+    var displayRepresentation: DisplayRepresentation {
+        return DisplayRepresentation(
+            title: LocalizedStringResource(stringLiteral: "✅ \(message)"),
+            subtitle: LocalizedStringResource(stringLiteral: "Activity ID: \(activityId)")
+        )
+    }
+}
+
+struct UserProfileResult: AppEntity {
+    static var typeDisplayRepresentation = TypeDisplayRepresentation(name: "User Profile")
+    static var defaultQuery = UserProfileResultQuery()
+    typealias ID = String
+    var id: ID { name }
+
+    let name: String
+    let interests: [String]
+    let upcomingActivities: Int
+    let totalActivities: Int
+
+    var displayRepresentation: DisplayRepresentation {
+        let interestsString = interests.joined(separator: ", ")
+        return DisplayRepresentation(
+            title: LocalizedStringResource(stringLiteral: "👤 \(name)"),
+            subtitle: LocalizedStringResource(stringLiteral: "Interests: \(interestsString) • \(upcomingActivities) upcoming • \(totalActivities) total")
+        )
+    }
+}
+
+// MARK: - Entity Queries
+
+struct ActivityIntentQuery: EntityQuery {
+    func entities(for identifiers: [String]) async throws -> [ActivityIntentResult] {
+        let mockService = MockDataService.shared
+        let activities = identifiers.compactMap { id in
+            mockService.getActivity(by: id)
+        }
+        
+        return activities.map { activity in
+            ActivityIntentResult(
+                id: activity.id,
+                title: activity.title,
+                sportType: activity.sportType,
+                dateTime: activity.dateTime,
+                location: activity.location,
+                availableSlots: activity.availableSlots
+            )
+        }
+    }
+    
+    func suggestedEntities() async throws -> [ActivityIntentResult] {
+        let mockService = MockDataService.shared
+        let activities = mockService.findActivities().prefix(5)
+        
+        return activities.map { activity in
+            ActivityIntentResult(
+                id: activity.id,
+                title: activity.title,
+                sportType: activity.sportType,
+                dateTime: activity.dateTime,
+                location: activity.location,
+                availableSlots: activity.availableSlots
+            )
+        }
+    }
+}
+
+struct JoinResultQuery: EntityQuery {
+    func entities(for identifiers: [String]) async throws -> [JoinResult] { [] }
+    func suggestedEntities() async throws -> [JoinResult] { [] }
+}
+
+struct CreateActivityResultQuery: EntityQuery {
+    func entities(for identifiers: [String]) async throws -> [CreateActivityResult] { [] }
+    func suggestedEntities() async throws -> [CreateActivityResult] { [] }
+}
+
+struct UserProfileResultQuery: EntityQuery {
+    func entities(for identifiers: [String]) async throws -> [UserProfileResult] { [] }
+    func suggestedEntities() async throws -> [UserProfileResult] { [] }
+}
+
+// MARK: - App Shortcuts
+
+struct ANISAppShortcuts: AppShortcutsProvider {
+    static var appShortcuts: [AppShortcut] {
+        return [
+            AppShortcut(
+                intent: FindActivitiesIntent(),
+                phrases: [
+                    "Find activities in \(.applicationName)",
+                    "Show me sports activities in \(.applicationName)",
+                    "Search for activities near me in \(.applicationName)"
+                ],
+                shortTitle: "Find Activities",
+                systemImageName: "sportscourt"
+            ),
+            AppShortcut(
+                intent: JoinActivityIntent(),
+                phrases: [
+                    "Join activity in \(.applicationName)",
+                    "Sign me up for an activity in \(.applicationName)",
+                    "Register for sports activity in \(.applicationName)"
+                ],
+                shortTitle: "Join Activity",
+                systemImageName: "person.badge.plus"
+            ),
+            AppShortcut(
+                intent: CreateActivityIntent(),
+                phrases: [
+                    "Create activity in \(.applicationName)",
+                    "Start a new sports session in \(.applicationName)",
+                    "Organize sports activity in \(.applicationName)"
+                ],
+                shortTitle: "Create Activity",
+                systemImageName: "plus.circle"
+            ),
+            AppShortcut(
+                intent: GetUserProfileIntent(),
+                phrases: [
+                    "Show my profile in \(.applicationName)",
+                    "What's my profile in \(.applicationName)",
+                    "My sports profile in \(.applicationName)"
+                ],
+                shortTitle: "My Profile",
+                systemImageName: "person.circle"
+            ),
+            AppShortcut(
+                intent: GetUpcomingActivitiesIntent(),
+                phrases: [
+                    "Show my upcoming activities in \(.applicationName)",
+                    "What activities do I have coming up in \(.applicationName)",
+                    "My sports schedule in \(.applicationName)"
+                ],
+                shortTitle: "Upcoming Activities",
+                systemImageName: "calendar"
+            )
+        ]
+    }
+}
+
+// MARK: - Error Handling
+
+enum AppIntentError: Swift.Error, LocalizedError {
+    case userNotFound
+    case activityNotFound
+    case joinFailed(String)
+    case createFailed(String)
+    
+    var errorDescription: String? {
+        switch self {
+        case .userNotFound:
+            return "User not found. Please make sure you're logged in."
+        case .activityNotFound:
+            return "Activity not found. It may have been cancelled or removed."
+        case .joinFailed(let message):
+            return "Failed to join activity: \(message)"
+        case .createFailed(let message):
+            return "Failed to create activity: \(message)"
+        }
+    }
+}


### PR DESCRIPTION
Connects App Intents to a new `MockDataService` to centralize mock data management and enable dynamic interactions.

The original implementation had hardcoded mock data within each `AppIntent`'s `perform` method, leading to redundant data and static behavior. This PR introduces a `MockDataService` singleton to manage activities and users, allowing intents to interact with a shared, mutable dataset for more realistic testing of create, join, and fetch operations.

---
<a href="https://cursor.com/background-agent?bcId=bc-f681399a-91af-4084-84e4-4e9821289423">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f681399a-91af-4084-84e4-4e9821289423">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

